### PR TITLE
feat: add email magic link auth

### DIFF
--- a/api/link-email.ts
+++ b/api/link-email.ts
@@ -1,0 +1,28 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const config = { runtime: 'nodejs' };
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_SERVICE_ROLE_KEY;
+const supabase = createClient(SUPABASE_URL!, SUPABASE_SERVICE_ROLE_KEY!);
+
+interface Req { method?: string; headers?: Record<string,string>; body?: any }
+interface Res { status:(n:number)=>Res; json:(v:any)=>void }
+
+export default async function handler(req: Req, res: Res){
+  if (req.method !== 'POST') return res.status(405).json({ ok:false, error:'method-not-allowed' });
+  try {
+    const auth = req.headers?.authorization || '';
+    if (!auth.startsWith('Bearer ')) return res.status(401).json({ ok:false, error:'missing-token' });
+    const token = auth.slice('Bearer '.length);
+    const { data: { user }, error: userErr } = await supabase.auth.getUser(token);
+    if (userErr || !user) return res.status(401).json({ ok:false, error:'invalid-token' });
+    const tgid = (req.body && req.body.tgid) ? Number(req.body.tgid) : NaN;
+    if (!tgid) return res.status(400).json({ ok:false, error:'missing-tgid' });
+    const { error } = await supabase.from('users').update({ auth_user_id: user.id, email: user.email }).eq('telegram_id', tgid);
+    if (error) return res.status(500).json({ ok:false, error:'link-failed' });
+    return res.json({ ok:true });
+  } catch {
+    return res.status(500).json({ ok:false, error:'server-error' });
+  }
+}

--- a/api/sync-pull.ts
+++ b/api/sync-pull.ts
@@ -17,43 +17,68 @@ const supabase = (function init(){
   return client;
 })();
 
-interface Req { method?: string; body?: unknown; }
+interface Req { method?: string; body?: unknown; headers?: Record<string,string>; }
 interface Res { status: (c:number)=>Res; json: (v:unknown)=>void; }
 
 export default async function handler(req: Req, res: Res) {
   try {
-  if (req.method !== 'POST') return res.status(405).json({ ok:false, error:'method-not-allowed' });
-  if (supabaseInitError) return res.status(500).json({ ok:false, error: supabaseInitError });
-  const body = (req.body as { initData?: string; since?: string; debug?: boolean } | undefined) || {};
-  const { initData, since, debug } = body;
-  if (debug) return res.json({ ok:false, debug:true, env:{ SUPABASE_URL: !!SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY: !!SUPABASE_SERVICE_ROLE_KEY, BOT_TOKEN: !!process.env.BOT_TOKEN }, supabaseInitError });
-  if (!initData) return res.status(400).json({ ok:false, error:'missing-initData', ...devReason('initData') });
-  if (!process.env.BOT_TOKEN) return res.status(500).json({ ok:false, error:'missing-bot-token' });
-  if (!isValidInitData(initData, process.env.BOT_TOKEN)) return res.status(401).json({ ok:false, error:'invalid-hmac', ...devReason('hmac') });
+    if (req.method !== 'POST') return res.status(405).json({ ok:false, error:'method-not-allowed' });
+    if (supabaseInitError) return res.status(500).json({ ok:false, error: supabaseInitError });
+    const auth = req.headers?.authorization || '';
+    if (auth.startsWith('Bearer ')) {
+      const token = auth.slice('Bearer '.length);
+      const { data: { user }, error: userErr } = await supabase.auth.getUser(token);
+      if (userErr || !user) return res.status(401).json({ ok:false, error:'invalid-token' });
+      const body = (req.body as { since?: string } | undefined) || {};
+      const { since } = body;
+      const { data: userRow, error: uErr } = await supabase.from('users').select('telegram_id, username, updated_at').eq('auth_user_id', user.id).limit(1).maybeSingle();
+      if (uErr) return res.status(500).json({ ok:false, error:'user-check-failed' });
+      if (!userRow) return res.status(410).json({ ok:false, error:'user-missing' });
+      const tgid = userRow.telegram_id as number;
+      if (!allow('pull:'+user.id, 2000)) return res.status(429).json({ ok:false, error:'rate-limited' });
+      let query = supabase.from('entries').select('date, emojis_enc, hue_enc, song_title_enc, song_artist_enc, updated_at').eq('telegram_id', tgid);
+      if (since && typeof since === 'string') query = query.gt('updated_at', since);
+      const { data, error } = await query.order('date', { ascending: true });
+      if (error) return res.status(500).json({ ok:false, error:'db-error' });
+      const rows = (data as { date:string|Date; emojis_enc:string|null; hue_enc:string|null; song_title_enc:string|null; song_artist_enc:string|null; updated_at:string }[]) || [];
+      const entries = rows.map(r => {
+        let emojis: string[] = [];
+        let hue: number | undefined;
+        let songTitle: string | undefined;
+        let songArtist: string | undefined;
+        try {
+          const dec = r.emojis_enc ? decryptStr(r.emojis_enc) : '';
+          const arr = dec ? JSON.parse(dec) : [];
+          if (Array.isArray(arr)) emojis = arr.filter(x=>typeof x==='string').slice(0,3);
+        } catch {}
+        if (r.hue_enc) {
+          const hStr = decryptStr(r.hue_enc); const hNum = parseInt(hStr,10); if(!isNaN(hNum) && hNum>=0 && hNum<=360) hue = hNum;
+        }
+        if (r.song_title_enc) songTitle = decryptStr(r.song_title_enc) || undefined;
+        if (r.song_artist_enc) songArtist = decryptStr(r.song_artist_enc) || undefined;
+        return { date: String(r.date), emojis, hue, song: (songTitle||songArtist)?{ title:songTitle, artist:songArtist }:undefined, updatedAt: new Date(r.updated_at).getTime() };
+      });
+      return res.json({ ok:true, entries, username: userRow.username, userUpdatedAt: userRow.updated_at });
+    }
+    const body = (req.body as { initData?: string; since?: string; debug?: boolean } | undefined) || {};
+    const { initData, since, debug } = body;
+    if (debug) return res.json({ ok:false, debug:true, env:{ SUPABASE_URL: !!SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY: !!SUPABASE_SERVICE_ROLE_KEY, BOT_TOKEN: !!process.env.BOT_TOKEN }, supabaseInitError });
+    if (!initData) return res.status(400).json({ ok:false, error:'missing-initData', ...devReason('initData') });
+    if (!process.env.BOT_TOKEN) return res.status(500).json({ ok:false, error:'missing-bot-token' });
+    if (!isValidInitData(initData, process.env.BOT_TOKEN)) return res.status(401).json({ ok:false, error:'invalid-hmac', ...devReason('hmac') });
     const u = parseTGUser(initData);
-  if (!u?.id) return res.status(400).json({ ok:false, error:'invalid-user', ...devReason('user') });
-
-  // Ensure user still exists (may have been deleted from another device)
-  const { data: userRow, error: userErr } = await supabase.from('users').select('telegram_id, username, updated_at').eq('telegram_id', u.id).limit(1).maybeSingle();
-  if (userErr) return res.status(500).json({ ok:false, error:'user-check-failed' });
-  if (!userRow) return res.status(410).json({ ok:false, error:'user-missing' });
-
-  // Rate limit pulls: one every 2s per user id
-  // We'll know ID only after validation, so delay rate check until after parsing user.
-  let query = supabase.from('entries')
-      .select('date, emojis_enc, hue_enc, song_title_enc, song_artist_enc, updated_at')
-      .eq('telegram_id', u.id);
-
-  if (!allow('pull:'+u.id, 2000)) return res.status(429).json({ ok:false, error:'rate-limited', ...devReason('rate') });
-
+    if (!u?.id) return res.status(400).json({ ok:false, error:'invalid-user', ...devReason('user') });
+    const { data: userRow, error: userErr } = await supabase.from('users').select('telegram_id, username, updated_at').eq('telegram_id', u.id).limit(1).maybeSingle();
+    if (userErr) return res.status(500).json({ ok:false, error:'user-check-failed' });
+    if (!userRow) return res.status(410).json({ ok:false, error:'user-missing' });
+    if (!allow('pull:'+u.id, 2000)) return res.status(429).json({ ok:false, error:'rate-limited', ...devReason('rate') });
+    let query = supabase.from('entries').select('date, emojis_enc, hue_enc, song_title_enc, song_artist_enc, updated_at').eq('telegram_id', u.id);
     if (since && typeof since === 'string') query = query.gt('updated_at', since);
-
     const { data, error } = await query.order('date', { ascending: true });
     if (error) {
       console.error('[sync-pull] query error', error.message);
       return res.status(500).json({ ok:false, error:'db-error' });
     }
-
     interface Row { date: string | Date; emojis_enc: string | null; hue_enc: string | null; song_title_enc: string | null; song_artist_enc: string | null; updated_at: string; }
     const rows: Row[] = (data as Row[]) || [];
     const entries = rows.map(r => {
@@ -73,9 +98,8 @@ export default async function handler(req: Req, res: Res) {
       if (r.song_artist_enc) songArtist = decryptStr(r.song_artist_enc) || undefined;
       return { date: String(r.date), emojis, hue, song: (songTitle || songArtist) ? { title: songTitle, artist: songArtist } : undefined, updatedAt: new Date(r.updated_at).getTime() };
     });
-
-  console.log('[sync-pull] entries returned', { telegram_id: u.id, count: entries.length, since: since || null });
-  res.json({ ok:true, entries, username: userRow.username, userUpdatedAt: userRow.updated_at });
+    console.log('[sync-pull] entries returned', { telegram_id: u.id, count: entries.length, since: since || null });
+    res.json({ ok:true, entries, username: userRow.username, userUpdatedAt: userRow.updated_at });
   } catch (e) {
     console.error('[sync-pull] unexpected', (e as Error)?.message);
     res.status(500).json({ ok:false, error:'server-error' });

--- a/api/sync-push.ts
+++ b/api/sync-push.ts
@@ -20,33 +20,96 @@ const supabase = (function init(){
 
 interface IncomingEntry { date: string; emojis: string[]; hue?: number; song?: { title?: string; artist?: string }; updatedAt: number; }
 
-interface Req { method?: string; body?: unknown; }
+interface Req { method?: string; body?: unknown; headers?: Record<string,string>; }
 interface Res { status: (c:number)=>Res; json: (v:unknown)=>void; }
 
 export default async function handler(req: Req, res: Res) {
   try {
-  if (req.method !== 'POST') return res.status(405).json({ ok:false, error:'method-not-allowed' });
-  if (supabaseInitError) return res.status(500).json({ ok:false, error: supabaseInitError });
-  const body = (req.body as { initData?: string; entries?: unknown; debug?: boolean } | undefined) || {};
-  const { initData, entries, debug } = body;
-  if (debug) return res.json({ ok:false, debug:true, env:{ SUPABASE_URL: !!SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY: !!SUPABASE_SERVICE_ROLE_KEY, BOT_TOKEN: !!process.env.BOT_TOKEN }, supabaseInitError });
-  if (!initData) return res.status(400).json({ ok:false, error:'missing-initData', ...devReason('initData') });
-  if (!Array.isArray(entries)) return res.status(400).json({ ok:false, error:'entries-not-array' });
-  if (!process.env.BOT_TOKEN) return res.status(500).json({ ok:false, error:'missing-bot-token' });
-  if (!isValidInitData(initData, process.env.BOT_TOKEN)) return res.status(401).json({ ok:false, error:'invalid-hmac', ...devReason('hmac') });
+    if (req.method !== 'POST') return res.status(405).json({ ok:false, error:'method-not-allowed' });
+    if (supabaseInitError) return res.status(500).json({ ok:false, error: supabaseInitError });
+    const auth = req.headers?.authorization || '';
+    if (auth.startsWith('Bearer ')) {
+      const token = auth.slice('Bearer '.length);
+      const { data: { user }, error: userErr } = await supabase.auth.getUser(token);
+      if (userErr || !user) return res.status(401).json({ ok:false, error:'invalid-token' });
+      const body = (req.body as { entries?: unknown } | undefined) || {};
+      const { entries } = body;
+      if (!Array.isArray(entries)) return res.status(400).json({ ok:false, error:'entries-not-array' });
+      const { data: userRow, error: uErr } = await supabase.from('users').select('telegram_id').eq('auth_user_id', user.id).limit(1).maybeSingle();
+      if (uErr) return res.status(500).json({ ok:false, error:'user-check-failed' });
+      if (!userRow) return res.status(410).json({ ok:false, error:'user-missing' });
+      const tgid = userRow.telegram_id as number;
+      if (!allow('push:'+user.id, 400)) return res.status(429).json({ ok:false, error:'rate-limited' });
+      const todayPlus = Date.now() + 2*86400000;
+      const minDate = new Date('2023-01-01T00:00:00Z').getTime();
+      const clean: IncomingEntry[] = (entries as unknown[]).slice(0,50).map(r => {
+        const obj = r as Partial<IncomingEntry>;
+        const dateValid = typeof obj.date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(obj.date);
+        const dateStr = dateValid ? obj.date as string : 'invalid';
+        const dateMs = dateValid ? Date.parse(dateStr+'T00:00:00Z') : NaN;
+        if (!dateValid || isNaN(dateMs) || dateMs < minDate || dateMs > todayPlus) return { date:'invalid', emojis:[], updatedAt:0 } as IncomingEntry;
+        let emojis = Array.isArray(obj.emojis) ? obj.emojis.filter(e=>typeof e==='string').map(e=>e.trim()).filter(Boolean) : [];
+        emojis = Array.from(new Set(emojis)).slice(0,3);
+        const hue = typeof obj.hue === 'number' && emojis.length>0 ? Math.min(360, Math.max(0, Math.round(obj.hue))) : undefined;
+        const song = obj.song && typeof obj.song === 'object' ? {
+          title: typeof obj.song.title === 'string' ? obj.song.title.slice(0,48).trim() : undefined,
+          artist: typeof obj.song.artist === 'string' ? obj.song.artist.slice(0,40).trim() : undefined,
+        } : undefined;
+        const normalizedSong = (song && !(song.title || song.artist)) ? undefined : song;
+        const updatedAt = typeof obj.updatedAt === 'number' ? obj.updatedAt : Date.now();
+        return { date: dateStr, emojis, hue, song: normalizedSong, updatedAt };
+      }).filter(e => e.date !== 'invalid');
+      if (!clean.length) return res.json({ ok:true, count:0 });
+      const dates = clean.map(c=>c.date);
+      const { data: existing } = await supabase.from('entries').select('date, updated_at').eq('telegram_id', tgid).in('date', dates);
+      const existingMap = new Map<string, number>();
+      for (const row of existing || []) { try { existingMap.set(String(row.date), new Date(row.updated_at as string).getTime()); } catch{} }
+      const toUpsert = clean.filter(c=>{ const prev = existingMap.get(c.date); return prev==null || c.updatedAt>prev; }).map(e=>({
+        date: e.date,
+        emojis_enc: encryptStr(JSON.stringify(e.emojis)),
+        hue_enc: typeof e.hue==='number'? encryptStr(String(e.hue)) : null,
+        song_title_enc: e.song?.title ? encryptStr(e.song.title) : null,
+        song_artist_enc: e.song?.artist ? encryptStr(e.song.artist) : null,
+        updated_at: new Date(e.updatedAt).toISOString()
+      }));
+      if (toUpsert.length) {
+        try {
+          const { error: upErr } = await supabase.from('entries').upsert(toUpsert.map(e=>({ telegram_id: tgid, ...e })), { onConflict:'telegram_id,date' });
+          if (upErr) throw upErr;
+        } catch (err) {
+          const inserts: any[] = [];
+          const updates: { date:string; fields:any }[] = [];
+          for (const r of toUpsert) {
+            const prev = existingMap.get(r.date);
+            const fields = { emojis_enc:r.emojis_enc, hue_enc:r.hue_enc, song_title_enc:r.song_title_enc, song_artist_enc:r.song_artist_enc, updated_at:r.updated_at };
+            if (prev==null) inserts.push({ telegram_id: tgid, date:r.date, ...fields }); else updates.push({ date:r.date, fields });
+          }
+          if (inserts.length) {
+            const { error: insErr } = await supabase.from('entries').insert(inserts);
+            if (insErr) return res.status(500).json({ ok:false, error:'db-insert-failed' });
+          }
+          for (const u of updates) {
+            const { error: updErr } = await supabase.from('entries').update(u.fields).eq('telegram_id', tgid).eq('date', u.date);
+            if (updErr) return res.status(500).json({ ok:false, error:'db-update-failed' });
+          }
+        }
+      }
+      return res.json({ ok:true, count: toUpsert.length });
+    }
+    const body = (req.body as { initData?: string; entries?: unknown; debug?: boolean } | undefined) || {};
+    const { initData, entries, debug } = body;
+    if (debug) return res.json({ ok:false, debug:true, env:{ SUPABASE_URL: !!SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY: !!SUPABASE_SERVICE_ROLE_KEY, BOT_TOKEN: !!process.env.BOT_TOKEN }, supabaseInitError });
+    if (!initData) return res.status(400).json({ ok:false, error:'missing-initData', ...devReason('initData') });
+    if (!Array.isArray(entries)) return res.status(400).json({ ok:false, error:'entries-not-array' });
+    if (!process.env.BOT_TOKEN) return res.status(500).json({ ok:false, error:'missing-bot-token' });
+    if (!isValidInitData(initData, process.env.BOT_TOKEN)) return res.status(401).json({ ok:false, error:'invalid-hmac', ...devReason('hmac') });
     const u = parseTGUser(initData);
-  if (!u?.id) return res.status(400).json({ ok:false, error:'invalid-user', ...devReason('user') });
-
-  // User may have been deleted remotely
-  const { data: userRow, error: userErr } = await supabase.from('users').select('telegram_id').eq('telegram_id', u.id).limit(1).maybeSingle();
-  if (userErr) return res.status(500).json({ ok:false, error:'user-check-failed' });
-  if (!userRow) return res.status(410).json({ ok:false, error:'user-missing' });
-
-    // Rate limit (per user) lightweight: at most 1 push every 400ms
-  if (!allow('push:'+u.id, 400)) return res.status(429).json({ ok:false, error:'rate-limited', ...devReason('rate') });
-
-    // Sanitize & limit payload (defense-in-depth)
-    const todayPlus = Date.now() + 2*86400000; // allow up to +2 days future (clock drift)
+    if (!u?.id) return res.status(400).json({ ok:false, error:'invalid-user', ...devReason('user') });
+    const { data: userRow, error: userErr } = await supabase.from('users').select('telegram_id').eq('telegram_id', u.id).limit(1).maybeSingle();
+    if (userErr) return res.status(500).json({ ok:false, error:'user-check-failed' });
+    if (!userRow) return res.status(410).json({ ok:false, error:'user-missing' });
+    if (!allow('push:'+u.id, 400)) return res.status(429).json({ ok:false, error:'rate-limited', ...devReason('rate') });
+    const todayPlus = Date.now() + 2*86400000;
     const minDate = new Date('2023-01-01T00:00:00Z').getTime();
     const clean: IncomingEntry[] = (entries as unknown[]).slice(0, 50).map(r => {
       const obj = r as Partial<IncomingEntry>;
@@ -55,33 +118,26 @@ export default async function handler(req: Req, res: Res) {
       const dateMs = dateValid ? Date.parse(dateStr+'T00:00:00Z') : NaN;
       if (!dateValid || isNaN(dateMs) || dateMs < minDate || dateMs > todayPlus) return { date:'invalid', emojis:[], updatedAt:0 } as IncomingEntry;
       let emojis = Array.isArray(obj.emojis) ? obj.emojis.filter(e => typeof e === 'string').map(e=>e.trim()).filter(Boolean) : [];
-      // Deduplicate & cap
       emojis = Array.from(new Set(emojis)).slice(0,3);
       const hue = typeof obj.hue === 'number' && emojis.length>0 ? Math.min(360, Math.max(0, Math.round(obj.hue))) : undefined;
       const song = obj.song && typeof obj.song === 'object' ? {
         title: typeof obj.song.title === 'string' ? obj.song.title.slice(0,48).trim() : undefined,
         artist: typeof obj.song.artist === 'string' ? obj.song.artist.slice(0,40).trim() : undefined,
       } : undefined;
-      // Treat empty song object as undefined
       const normalizedSong = (song && !(song.title || song.artist)) ? undefined : song;
       const updatedAt = typeof obj.updatedAt === 'number' ? obj.updatedAt : Date.now();
       return { date: dateStr, emojis, hue, song: normalizedSong, updatedAt };
     }).filter(e => e.date !== 'invalid');
-
-  if (!clean.length) return res.json({ ok:true, count: 0 });
-
-    // Fetch existing rows for these dates in one round-trip
+    if (!clean.length) return res.json({ ok:true, count: 0 });
     const dates = clean.map(c => c.date);
     const { data: existing } = await supabase.from('entries')
       .select('date, updated_at')
       .eq('telegram_id', u.id)
       .in('date', dates);
-
     const existingMap = new Map<string, number>();
     for (const row of existing || []) {
       try { existingMap.set(String(row.date), new Date(row.updated_at as string).getTime()); } catch { /* ignore */ }
     }
-
     const toUpsert = clean.filter(c => {
       const prev = existingMap.get(c.date);
       return prev == null || c.updatedAt > prev;
@@ -93,17 +149,14 @@ export default async function handler(req: Req, res: Res) {
       song_artist_enc: e.song?.artist ? encryptStr(e.song.artist) : null,
       updated_at: new Date(e.updatedAt).toISOString()
     }));
-
     if (toUpsert.length) {
-      // Try the convenient upsert first (relies on a unique constraint on telegram_id+date)
       try {
         const { error: upErr } = await supabase.from('entries').upsert(toUpsert.map(e => ({ telegram_id: u.id, ...e })), { onConflict: 'telegram_id,date' });
         if (upErr) throw upErr;
         console.log('[sync-push] entries upserted', { telegram_id: u.id, count: toUpsert.length, method: 'enc-direct' });
       } catch (err: unknown) {
-        // If the error indicates the DB doesn't have the expected unique constraint, fall back to safe insert/update per-row.
-  const maybeErr = err as Record<string, unknown> | undefined;
-  const msg = maybeErr && typeof maybeErr.message === 'string' ? maybeErr.message : String(err || '');
+        const maybeErr = err as Record<string, unknown> | undefined;
+        const msg = maybeErr && typeof maybeErr.message === 'string' ? maybeErr.message : String(err || '');
         console.warn('[sync-push] upsert failed, falling back to manual insert/update', msg);
         const inserts: Array<Record<string, unknown>> = [];
         const updates: { date: string; fields: Record<string, unknown> }[] = [];
@@ -113,7 +166,6 @@ export default async function handler(req: Req, res: Res) {
           if (prev == null) inserts.push({ telegram_id: u.id, date: r.date, ...fields });
           else updates.push({ date: r.date, fields });
         }
-
         if (inserts.length) {
           const { error: insErr } = await supabase.from('entries').insert(inserts);
           if (insErr) {
@@ -121,7 +173,6 @@ export default async function handler(req: Req, res: Res) {
             return res.status(500).json({ ok:false, error:'db-insert-failed' });
           }
         }
-
         for (const urow of updates) {
           const { error: updErr } = await supabase.from('entries').update(urow.fields).eq('telegram_id', u.id).eq('date', urow.date);
           if (updErr) {
@@ -132,7 +183,6 @@ export default async function handler(req: Req, res: Res) {
         console.log('[sync-push] entries inserted/updated', { telegram_id: u.id, inserted: inserts.length, updated: updates.length, method: 'manual-fallback' });
       }
     }
-
     res.json({ ok:true, count: toUpsert.length });
   } catch (e) {
     console.error('[sync-push] unexpected', (e as Error)?.message);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ import IconButton from './components/IconButton';
 import EmojiTriangle from './components/EmojiTriangle';
 import EmojiPickerModal from './components/EmojiPickerModal';
 import AuraBlock from './components/AuraBlock';
-import LoginPage from './pages/LoginPage';
 import { supabase } from './lib/supabase';
 
 export default function App() {
@@ -88,9 +87,6 @@ export default function App() {
     window.history.replaceState({}, '', url.toString());
   }, [session]);
 
-  if (!isTG && !session && import.meta.env.MODE !== 'test') {
-    return <LoginPage />;
-  }
   // Telegram verification + initial cloud sync (telegram only)
   // Run this effect whenever `isTG` changes so startup sync runs when Telegram.WebApp
   // appears later (e.g. opening in another device) without requiring a manual reload.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,10 @@ export default function App() {
 
   // Track Supabase auth session for email-based logins
   useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => setSession(data.session));
+    (async () => {
+      try { await supabase.auth.initialize(); } catch { /* ignore */ }
+      try { const { data } = await supabase.auth.getSession(); setSession(data.session); } catch { /* ignore */ }
+    })();
     const { data: sub } = supabase.auth.onAuthStateChange((_evt, sess) => setSession(sess));
     return () => { sub.subscription.unsubscribe(); };
   }, []);

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,10 @@
 import { createClient } from '@supabase/supabase-js';
 
+const URL = import.meta.env.VITE_SUPABASE_URL || 'http://localhost';
+const KEY = import.meta.env.VITE_SUPABASE_ANON_KEY || 'anon';
 export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!,
-  { auth: { persistSession: false } }
+  URL,
+  KEY,
+  // Persist sessions so email-auth users remain logged in across reloads
+  { auth: { persistSession: true } }
 );

--- a/src/lib/sync.ts
+++ b/src/lib/sync.ts
@@ -1,10 +1,12 @@
 // Telegram-aware sync helpers (client-side)
 import type { Entry } from './types';
 import { loadEntries, saveEntries, loadReminders, saveReminders } from './storage';
+import { supabase } from './supabase';
 
 const SYNC_KEY = 'flowday_last_sync_iso_v1';
 const CLOUD_FLAG_KEY = 'flowday_cloud_enabled_v1';
 const RETRY_MS = 6_000;
+const TG_ID_KEY = 'flowday_tgid';
 
 // Narrow window typing for Telegram detection without using any
 interface TGWin { Telegram?: { WebApp?: { initData?: string } } }
@@ -66,6 +68,10 @@ export async function verifyTelegram(tz?: string) {
     if (data && typeof data === 'object' && 'exists' in data) {
       const existsVal = (data as { exists?: unknown }).exists;
       if (existsVal === true) localStorage.setItem(CLOUD_FLAG_KEY,'1');
+      const tgid = (data as { telegram_id?: unknown }).telegram_id;
+      if (typeof tgid === 'number' || typeof tgid === 'string') {
+        try { localStorage.setItem(TG_ID_KEY, String(tgid)); } catch { /* ignore */ }
+      }
       const serverUsername = (data as { username?: unknown }).username;
       if (typeof serverUsername === 'string') {
         try {
@@ -95,36 +101,62 @@ export async function verifyTelegram(tz?: string) {
   } catch { /* silent */ }
 }
 export async function syncPull(): Promise<number | null> {
-  if (!isTG()) return null;
+  const { data: sessData } = await supabase.auth.getSession();
+  const session = sessData.session;
+  const usingTG = isTG();
+  if (!usingTG && !session) return null;
   if (!isCloudEnabled()) return null;
-  const initData = await waitForInitData();
-  if (!initData) return null;
   const since = localStorage.getItem(SYNC_KEY) || '';
-  try {
-    const { res, data } = await postJSON('/api/sync-pull', { initData, since });
-    if (res.status === 410) { disableCloud(); stopPeriodicPull(); return null; }
-    if (res.status === 429) {
-      periodicIntervalMs = Math.min(120000, Math.round(periodicIntervalMs * 1.5));
-      if (periodicTimer) { clearInterval(periodicTimer); periodicTimer = setInterval(()=> { syncPull(); }, periodicIntervalMs); }
-      return null;
-    } else if (res.ok && periodicIntervalMs !== 60000) {
-      periodicIntervalMs = 60000;
-      if (periodicTimer) { clearInterval(periodicTimer); periodicTimer = setInterval(()=> { syncPull(); }, periodicIntervalMs); }
-    }
-    if (!res.ok || !data?.ok || !Array.isArray(data.entries)) return null;
-    if (typeof data.username === 'string') {
+    if (usingTG) {
+      const initData = await waitForInitData();
+      if (!initData) return null;
       try {
-        const raw = localStorage.getItem('flowday_user_v1');
-        if (raw) { const obj = JSON.parse(raw); if (obj && typeof obj === 'object' && obj.username !== data.username) { obj.username = data.username; localStorage.setItem('flowday_user_v1', JSON.stringify(obj)); } }
-      } catch { /* ignore */ }
+        const { res, data } = await postJSON('/api/sync-pull', { initData, since });
+        if (res.status === 410) { disableCloud(); stopPeriodicPull(); return null; }
+        if (res.status === 429) {
+          periodicIntervalMs = Math.min(120000, Math.round(periodicIntervalMs * 1.5));
+          if (periodicTimer) { clearInterval(periodicTimer); periodicTimer = setInterval(()=> { syncPull(); }, periodicIntervalMs); }
+          return null;
+        } else if (res.ok && periodicIntervalMs !== 60000) {
+          periodicIntervalMs = 60000;
+          if (periodicTimer) { clearInterval(periodicTimer); periodicTimer = setInterval(()=> { syncPull(); }, periodicIntervalMs); }
+        }
+        if (!res.ok || !data?.ok || !Array.isArray(data.entries)) return null;
+        if (typeof data.username === 'string') {
+          try {
+            const raw = localStorage.getItem('flowday_user_v1');
+            if (raw) { const obj = JSON.parse(raw); if (obj && typeof obj === 'object' && obj.username !== data.username) { obj.username = data.username; localStorage.setItem('flowday_user_v1', JSON.stringify(obj)); } }
+          } catch { /* ignore */ }
+        }
+        const pulled = data.entries as Entry[];
+        const local = loadEntries();
+        const merged = mergeByNewer(local, pulled);
+        saveEntries(merged);
+        localStorage.setItem(SYNC_KEY, new Date().toISOString());
+        return pulled.length;
+      } catch { return null; }
+    } else if (session) {
+      try {
+        const res = await fetch('/api/sync-pull', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.access_token}`
+          },
+          body: JSON.stringify({ since })
+        });
+        if (res.status === 410) { disableCloud(); stopPeriodicPull(); return null; }
+        const data = await res.json().catch(()=>null);
+        if (!res.ok || !data?.ok || !Array.isArray(data.entries)) return null;
+        const pulled = data.entries as Entry[];
+        const local = loadEntries();
+        const merged = mergeByNewer(local, pulled);
+        saveEntries(merged);
+        localStorage.setItem(SYNC_KEY, new Date().toISOString());
+        return pulled.length;
+      } catch { return null; }
     }
-    const pulled = data.entries as Entry[];
-    const local = loadEntries();
-    const merged = mergeByNewer(local, pulled);
-    saveEntries(merged);
-    localStorage.setItem(SYNC_KEY, new Date().toISOString());
-    return pulled.length;
-  } catch { return null; }
+    return null;
 }
 
 type PendingPush = { entry: Entry; attempts: number };
@@ -140,44 +172,78 @@ function flushPush() {
 }
 
 async function rawSyncPush(pending: PendingPush[]) {
-  if (!isTG() || !pending.length) return;
+  if (!pending.length) return;
   if (!isCloudEnabled()) { pushQueue = []; return; }
-  const initData = await waitForInitData();
-  if (!initData) { pushQueue.push(...pending); setTimeout(flushPush, 500); return; }
-  const entries = pending.map(p => p.entry);
-  try {
-    const { res } = await postJSON('/api/sync-push', { initData, entries });
-    if (res.status === 410) { disableCloud(); stopPeriodicPull(); return; }
-    if (!res.ok) {
-      if ([429,500,502,503,504].includes(res.status)) {
-        for (const p of pending) {
-          if (p.attempts < 5) {
-            const delay = Math.min(30000, 1000 * Math.pow(2, p.attempts));
-            pushQueue.push({ entry: p.entry, attempts: p.attempts + 1 });
-            setTimeout(flushPush, delay);
+  const { data: sessData } = await supabase.auth.getSession();
+  const session = sessData.session;
+  const usingTG = isTG();
+    if (usingTG) {
+      const initData = await waitForInitData();
+      if (!initData) { pushQueue.push(...pending); setTimeout(flushPush, 500); return; }
+      const entries = pending.map(p => p.entry);
+      try {
+        const { res } = await postJSON('/api/sync-push', { initData, entries });
+        if (res.status === 410) { disableCloud(); stopPeriodicPull(); return; }
+        if (!res.ok) {
+          if ([429,500,502,503,504].includes(res.status)) {
+            for (const p of pending) {
+              if (p.attempts < 5) {
+                const delay = Math.min(30000, 1000 * Math.pow(2, p.attempts));
+                pushQueue.push({ entry: p.entry, attempts: p.attempts + 1 });
+                setTimeout(flushPush, delay);
+              }
+            }
           }
+          return;
         }
+        if (nextPullAfterPushTO) clearTimeout(nextPullAfterPushTO);
+        nextPullAfterPushTO = setTimeout(()=> { syncPull(); }, 5000);
+      } catch {
+        for (const p of pending) { if (p.attempts < 3) pushQueue.push({ entry: p.entry, attempts: p.attempts + 1 }); }
+        setTimeout(flushPush, RETRY_MS);
       }
-      return;
+    } else if (session) {
+      const entries = pending.map(p => p.entry);
+      try {
+        const res = await fetch('/api/sync-push', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${session.access_token}`
+          },
+          body: JSON.stringify({ entries })
+        });
+        if (res.status === 410) { disableCloud(); stopPeriodicPull(); return; }
+        if (!res.ok) {
+          if ([429,500,502,503,504].includes(res.status)) {
+            for (const p of pending) {
+              if (p.attempts < 5) {
+                const delay = Math.min(30000, 1000 * Math.pow(2, p.attempts));
+                pushQueue.push({ entry: p.entry, attempts: p.attempts + 1 });
+                setTimeout(flushPush, delay);
+              }
+            }
+          }
+          return;
+        }
+        if (nextPullAfterPushTO) clearTimeout(nextPullAfterPushTO);
+        nextPullAfterPushTO = setTimeout(()=> { syncPull(); }, 5000);
+      } catch {
+        for (const p of pending) { if (p.attempts < 3) pushQueue.push({ entry: p.entry, attempts: p.attempts + 1 }); }
+        setTimeout(flushPush, RETRY_MS);
+      }
     }
-    if (nextPullAfterPushTO) clearTimeout(nextPullAfterPushTO);
-    nextPullAfterPushTO = setTimeout(()=> { syncPull(); }, 5000);
-  } catch {
-    for (const p of pending) { if (p.attempts < 3) pushQueue.push({ entry: p.entry, attempts: p.attempts + 1 }); }
-    setTimeout(flushPush, RETRY_MS);
-  }
 }
 
 export function queueSyncPush(entry: Entry) {
-  if (!isTG()) return;
-  pushQueue = pushQueue.filter(e => e.entry.date !== entry.date); // dedupe
+  pushQueue = pushQueue.filter(e => e.entry.date !== entry.date);
   pushQueue.push({ entry, attempts: 0 });
   if (pushTimer) clearTimeout(pushTimer);
   pushTimer = setTimeout(flushPush, 700);
 }
 
 export function queueSyncPushMany(entries: Entry[]) {
-  if (!isTG() || !entries.length) return;
+  if (!entries.length) return;
   const setDates = new Set(entries.map(e=>e.date));
   pushQueue = pushQueue.filter(e => !setDates.has(e.entry.date));
   for (const e of entries) pushQueue.push({ entry: e, attempts: 0 });
@@ -186,18 +252,19 @@ export function queueSyncPushMany(entries: Entry[]) {
 }
 
 export async function initialFullSyncIfNeeded() {
-  if (!isTG()) return;
+  const { data: sessData } = await supabase.auth.getSession();
+  const session = sessData.session;
+  const usingTG = isTG();
+  if (!usingTG && !session) return;
   if (!isCloudEnabled()) return;
-  await waitForInitData();
+  if (usingTG) await waitForInitData();
   const FLAG = 'flowday_initial_sync_done_v1';
   if (localStorage.getItem(FLAG)) return; // already performed
-  // Perform pull first to avoid overwriting cloud data
-  const pulled = await syncPull(); // returns count or null
+  const pulled = await syncPull();
   const local = loadEntries();
   if ((pulled === 0 || pulled === null) && local.length) {
-    // Cloud empty (or unknown) but we have local entries -> push all
-  queueSyncPushMany(local);
-  flushPush();
+    queueSyncPushMany(local);
+    flushPush();
   }
   localStorage.setItem(FLAG, '1');
 }
@@ -206,10 +273,14 @@ export async function initialFullSyncIfNeeded() {
 let periodicTimer: ReturnType<typeof setInterval> | null = null;
 let periodicIntervalMs = 60000;
 export function startPeriodicPull() {
-  if (!isTG()) return;
-  if (!isCloudEnabled()) return;
-  if (periodicTimer) return;
-  periodicTimer = setInterval(()=> { syncPull(); }, periodicIntervalMs);
+  supabase.auth.getSession().then(({ data }) => {
+    const session = data.session;
+    const usingTG = isTG();
+    if (!usingTG && !session) return;
+    if (!isCloudEnabled()) return;
+    if (periodicTimer) return;
+    periodicTimer = setInterval(()=> { syncPull(); }, periodicIntervalMs);
+  });
 }
 export function stopPeriodicPull() { if (periodicTimer) { clearInterval(periodicTimer); periodicTimer = null; } }
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+export default function LoginPage(){
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<'idle'|'sent'|'error'>('idle');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSend(e: React.FormEvent){
+    e.preventDefault();
+    if (!email.trim()) return;
+    setLoading(true);
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: window.location.origin }
+    });
+    if (error) {
+      setStatus('error');
+    } else {
+      setStatus('sent');
+    }
+    setLoading(false);
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-black text-white p-4">
+      <h1 className="text-xl font-semibold mb-4">Flowday</h1>
+      <form onSubmit={handleSend} className="w-full max-w-sm space-y-3">
+        <input
+          type="email"
+          value={email}
+          onChange={e=>setEmail(e.target.value)}
+          placeholder="you@example.com"
+          className="w-full px-3 py-2 rounded-md bg-white/10 text-sm outline-none ring-1 ring-white/20 focus:ring-white/40"
+          disabled={loading || status==='sent'}
+        />
+        <button
+          type="submit"
+          disabled={loading || status==='sent'}
+          className="w-full px-3 py-2 rounded-md bg-white/20 hover:bg-white/30 transition text-sm font-medium disabled:opacity-40"
+        >
+          Send Magic Link
+        </button>
+      </form>
+      {status==='sent' && (
+        <p className="mt-4 text-sm text-green-400">Check your inbox for the login link.</p>
+      )}
+      {status==='error' && (
+        <p className="mt-4 text-sm text-red-400">Couldn't send link. Try again later.</p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { supabase } from '../lib/supabase';
 
+const SITE_URL = import.meta.env.VITE_SITE_URL || window.location.origin;
+
 export default function LoginPage(){
   const [email, setEmail] = useState('');
   const [status, setStatus] = useState<'idle'|'sent'|'error'>('idle');
@@ -12,7 +14,7 @@ export default function LoginPage(){
     setLoading(true);
     const { error } = await supabase.auth.signInWithOtp({
       email,
-      options: { emailRedirectTo: window.location.origin }
+      options: { emailRedirectTo: SITE_URL }
     });
     if (error) {
       setStatus('error');

--- a/supabase.sql
+++ b/supabase.sql
@@ -4,6 +4,7 @@
 create table if not exists public.users (
   telegram_id bigint primary key,
   username text,
+  email text,
   first_name text,
   last_name text,
   language_code text,


### PR DESCRIPTION
## Summary
- allow email magic link login via Supabase
- link Telegram accounts to email and keep sessions in sync
- add serverless endpoints for email-based sync and linking
- consolidate sync API to reuse existing endpoints and reduce function count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaf3556fa483279f5224a8fbb41f4e