### PR TITLE
feat: add web email magic link sign in

### DIFF
--- a/src/lib/webAuth.ts
+++ b/src/lib/webAuth.ts
@@ -1,0 +1,31 @@
+import { supabase } from './supabase';
+import type { Session } from '@supabase/supabase-js';
+
+const STORAGE_KEY = 'flowday_supabase_session_v1';
+
+export async function initSessionFromStorage(): Promise<Session | null> {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const { access_token, refresh_token } = JSON.parse(raw);
+    if (!access_token || !refresh_token) return null;
+    const { data, error } = await supabase.auth.setSession({ access_token, refresh_token });
+    if (error) { clearStoredSession(); return null; }
+    return data.session;
+  } catch {
+    return null;
+  }
+}
+
+export function storeSession(session: Session) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      access_token: session.access_token,
+      refresh_token: session.refresh_token,
+    }));
+  } catch { /* ignore */ }
+}
+
+export function clearStoredSession() {
+  try { localStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import AuthCallback from './pages/AuthCallback.tsx'
 import { initTelegram, tg } from './lib/telegram';
 
 // Attempt immediate init; if not yet present (script may load async), retry a few times.
@@ -11,8 +12,17 @@ function tryInitTG(attempt=0){
 }
 tryInitTG();
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+const root = createRoot(document.getElementById('root')!);
+if (window.location.pathname === '/auth/callback') {
+  root.render(
+    <StrictMode>
+      <AuthCallback />
+    </StrictMode>
+  );
+} else {
+  root.render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  );
+}

--- a/src/pages/AuthCallback.tsx
+++ b/src/pages/AuthCallback.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../lib/supabase';
+import { storeSession } from '../lib/webAuth';
+
+export default function AuthCallback() {
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const url = new URL(window.location.href);
+      const tokenHash = url.searchParams.get('token_hash');
+      let session = null;
+      if (tokenHash) {
+        const { data, error } = await supabase.auth.verifyOtp({ token_hash: tokenHash, type: 'email' });
+        if (!error) session = data.session; else setError(true);
+      } else {
+        const { data } = await supabase.auth.getSession();
+        session = data.session; if (!session) setError(true);
+      }
+      if (session) {
+        storeSession(session);
+        const redirect = localStorage.getItem('flowday_post_auth') || '/';
+        localStorage.removeItem('flowday_post_auth');
+        window.location.replace(redirect);
+      }
+    })();
+  }, []);
+
+  if (error) {
+    return (
+      <div className="p-6 text-center text-sm text-white/80">
+        <p className="mb-4">Link expired or invalid.</p>
+        <button
+          type="button"
+          className="px-3 py-1.5 text-xs font-medium rounded-md bg-white/5 ring-1 ring-white/10 hover:bg-white/10"
+          onClick={() => { window.location.href = '/'; }}
+        >
+          Send a new link
+        </button>
+      </div>
+    );
+  }
+
+  return <div className="p-6 text-center text-sm text-white/80">Completing sign in…</div>;
+}


### PR DESCRIPTION
## Summary
- add Supabase email magic link sign in for web builds with session persistence
- keep Telegram-only sign in inside mini app
- handle magic link callback via new `/auth/callback` route
- split settings forms to avoid nested forms and render root component conditionally

## Testing
- `VITE_SUPABASE_URL=http://localhost VITE_SUPABASE_ANON_KEY=public npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab0fc2033083279a25de311d58c08c