### PR TITLE
feat: implement email auth and supabase sync

### DIFF
--- a/api/email-delete.ts
+++ b/api/email-delete.ts
@@ -1,0 +1,36 @@
+import { createClient } from '@supabase/supabase-js';
+
+export const config = { runtime: 'nodejs' };
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.VITE_SUPABASE_SERVICE_ROLE_KEY;
+let supabaseInitError: string | null = null;
+const supabase = (function init(){
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) { supabaseInitError = 'missing-supabase-env'; return null as unknown as ReturnType<typeof createClient>; }
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+})();
+
+interface Req { method?: string; headers?: Record<string, string | undefined>; }
+interface Res { status: (c:number)=>Res; json: (v:unknown)=>void; }
+
+export default async function handler(req: Req, res: Res) {
+  try {
+    if (req.method !== 'POST') return res.status(405).json({ ok:false, error:'method-not-allowed' });
+    if (supabaseInitError) return res.status(500).json({ ok:false, error: supabaseInitError });
+    const auth = req.headers?.authorization || '';
+    const token = auth.startsWith('Bearer ') ? auth.slice(7) : null;
+    if (!token) return res.status(401).json({ ok:false, error:'missing-token' });
+    const { data: { user }, error: userErr } = await supabase.auth.getUser(token);
+    if (userErr || !user) return res.status(401).json({ ok:false, error:'invalid-token' });
+    const uid = user.id;
+    const { error: e1 } = await supabase.from('entries').delete().eq('auth_user_id', uid);
+    const { error: e2 } = await supabase.from('reminders').delete().eq('auth_user_id', uid);
+    const { error: e3 } = await supabase.from('users').delete().eq('auth_user_id', uid);
+    const { error: e4 } = await supabase.auth.admin.deleteUser(uid);
+    if (e1 || e2 || e3 || e4) return res.status(500).json({ ok:false, error:'delete-failed' });
+    res.json({ ok:true });
+  } catch (e) {
+    console.error('[email-delete] unexpected', (e as Error)?.message);
+    res.status(500).json({ ok:false, error:'server-error' });
+  }
+}

--- a/src/lib/emailAuth.ts
+++ b/src/lib/emailAuth.ts
@@ -1,0 +1,68 @@
+import { supabase } from './supabase';
+
+// Track auth state for synchronous checks
+let authed = false;
+
+// Initialize auth state
+supabase.auth.getSession().then(({ data }) => {
+  authed = !!data.session;
+});
+
+// Listen for auth changes
+supabase.auth.onAuthStateChange((_event, session) => {
+  authed = !!session;
+});
+
+export function isEmailAuthed(): boolean {
+  return authed;
+}
+
+export async function signInWithEmail(email: string) {
+  const { error } = await supabase.auth.signInWithOtp({
+    email,
+    options: { emailRedirectTo: `${window.location.origin}/auth/callback` },
+  });
+  return { error };
+}
+
+export async function completeEmailSignIn(url: string = window.location.href) {
+  const { error } = await supabase.auth.exchangeCodeForSession(url);
+  if (!error) {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (user) {
+      try {
+        await supabase.from('users').upsert(
+          { auth_user_id: user.id, email: user.email },
+          { onConflict: 'auth_user_id' }
+        );
+      } catch { /* ignore */ }
+    }
+  }
+  return { error };
+}
+
+export async function signOutEmail() {
+  await supabase.auth.signOut();
+}
+
+export async function deleteEmailAccount() {
+  const { data } = await supabase.auth.getSession();
+  const token = data.session?.access_token;
+  if (!token) return { error: 'not-authed' as const };
+  try {
+    const res = await fetch('/api/email-delete', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return { error: 'delete-failed' as const };
+    await supabase.auth.signOut();
+    return { error: null };
+  } catch {
+    return { error: 'delete-failed' as const };
+  }
+}
+
+export async function currentUserEmail(): Promise<string | null> {
+  const { data } = await supabase.auth.getSession();
+  return data.session?.user.email ?? null;
+}

--- a/src/lib/enc.ts
+++ b/src/lib/enc.ts
@@ -1,0 +1,60 @@
+const RAW_KEY = import.meta.env.VITE_ENC_KEY || import.meta.env.VITE_FLOWDAY_ENC_KEY || '';
+let keyPromise: Promise<CryptoKey | null> | null = null;
+
+async function getKey(): Promise<CryptoKey | null> {
+  if (keyPromise) return keyPromise;
+  if (!RAW_KEY) {
+    keyPromise = Promise.resolve(null);
+    return keyPromise;
+  }
+  keyPromise = crypto.subtle
+    .importKey(
+      'raw',
+      await crypto.subtle.digest('SHA-256', new TextEncoder().encode(RAW_KEY)),
+      { name: 'AES-GCM' },
+      false,
+      ['encrypt', 'decrypt']
+    )
+    .catch(() => null);
+  return keyPromise;
+}
+
+export function hasEnc(): boolean { return !!RAW_KEY; }
+
+export async function encryptStr(plain: string): Promise<string> {
+  const key = await getKey();
+  if (!key) return plain;
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const data = new TextEncoder().encode(plain);
+  const buf = new Uint8Array(await crypto.subtle.encrypt({ name: 'AES-GCM', iv }, key, data));
+  const tag = buf.slice(buf.length - 16);
+  const enc = buf.slice(0, buf.length - 16);
+  const out = new Uint8Array(12 + 16 + enc.length);
+  out.set(iv, 0);
+  out.set(tag, 12);
+  out.set(enc, 28);
+  let b64 = '';
+  out.forEach(b => { b64 += String.fromCharCode(b); });
+  return 'v1:' + btoa(b64);
+}
+
+export async function decryptStr(enc: string): Promise<string> {
+  const key = await getKey();
+  if (!key) return enc;
+  if (!enc.startsWith('v1:')) return enc;
+  try {
+    const raw = atob(enc.slice(3));
+    const bytes = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; i++) bytes[i] = raw.charCodeAt(i);
+    const iv = bytes.slice(0, 12);
+    const tag = bytes.slice(12, 28);
+    const data = bytes.slice(28);
+    const cipher = new Uint8Array(data.length + 16);
+    cipher.set(data, 0);
+    cipher.set(tag, data.length);
+    const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, key, cipher);
+    return new TextDecoder().decode(plain);
+  } catch {
+    return '';
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,7 +1,24 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL!,
-  import.meta.env.VITE_SUPABASE_ANON_KEY!,
-  { auth: { persistSession: false } }
-);
+// In tests or local non-configured environments the Supabase credentials may be
+// absent. To keep the module safe to import, fall back to a dummy client when
+// the environment variables are missing.
+function makeClient(): SupabaseClient {
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  const anon = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  const real = url && anon;
+  return createClient(
+    real ? url : 'https://example.com',
+    real ? anon : 'public-anon-key',
+    {
+      auth: {
+        // Persist the session so returning to the app keeps the user signed in
+        // and allow the SDK to refresh tokens automatically in the background.
+        persistSession: true,
+        autoRefreshToken: true,
+      },
+    }
+  );
+}
+
+export const supabase = makeClient();

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { initTelegram, tg } from './lib/telegram';
+import { completeEmailSignIn } from './lib/emailAuth';
 
 // Attempt immediate init; if not yet present (script may load async), retry a few times.
 function tryInitTG(attempt=0){
@@ -11,8 +12,15 @@ function tryInitTG(attempt=0){
 }
 tryInitTG();
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+if (window.location.pathname === '/auth/callback') {
+  completeEmailSignIn().finally(() => {
+    const dest = sessionStorage.getItem('flowday_post_auth_redirect') || '/';
+    window.location.replace(dest);
+  });
+} else {
+  createRoot(document.getElementById('root')!).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}


### PR DESCRIPTION
## Summary
- complete Supabase magic-link sign-in, user creation, and account deletion
- add AES-GCM encryption utilities and full email-based sync driver
- support email login/deletion and reminders sync in settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab3199de1083279f1ec9c56bf79b1c